### PR TITLE
refactor : multiple UiState in InstanceCreateViewModel

### DIFF
--- a/app/src/main/java/com/knu/cloud/components/data_grid/DataGrid.kt
+++ b/app/src/main/java/com/knu/cloud/components/data_grid/DataGrid.kt
@@ -11,9 +11,9 @@ import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
-import com.knu.cloud.model.instanceCreate.FlavorResponse
+import com.knu.cloud.model.instanceCreate.FlavorData
 import com.knu.cloud.model.instanceCreate.KeypairData
-import com.knu.cloud.model.instanceCreate.NetworkResponse
+import com.knu.cloud.model.instanceCreate.NetworkData
 import com.knu.cloud.model.instanceCreate.ImageData
 import com.knu.cloud.utils.*
 
@@ -94,7 +94,7 @@ fun <T> DataGridElementList(
         when(screenType) {
             "Flavor" ->
                 FlavorDataTableCell(
-                    item = item as FlavorResponse, // Flavor로 캐스팅
+                    item = item as FlavorData, // Flavor로 캐스팅
                     index = index,
                     type = type
                 ) { it, idx ->
@@ -110,7 +110,7 @@ fun <T> DataGridElementList(
                 }
             "Network" ->
                 NetworkDataTableCell(
-                    item = item as NetworkResponse, // Network로 캐스팅
+                    item = item as NetworkData, // Network로 캐스팅
                     index = index,
                     type = type
                 ) { it, idx ->

--- a/app/src/main/java/com/knu/cloud/components/text_input/TextInput.kt
+++ b/app/src/main/java/com/knu/cloud/components/text_input/TextInput.kt
@@ -40,14 +40,16 @@ fun ProjectTextInput(
     text: String = "",
     hint: String = "",
     label: String = "",
+    enabled: Boolean = true,
     trailingImage: Painter? = null,
     maxLines: Int = 1,
     singleLine: Boolean = false,
     keyboardController: SoftwareKeyboardController? = null,
-    passwordFocusRequester: FocusRequester = FocusRequester(),
+    focusRequester: FocusRequester = FocusRequester(),
     isError: State<Boolean> = remember { mutableStateOf(false) },
     errorMsg: State<String> = remember { mutableStateOf("") },
     onValueChangeListener: (String) -> Unit = {},
+    onDoneClicked : (String) -> Unit = {}
 ) {
 
     when (type) {
@@ -58,11 +60,12 @@ fun ProjectTextInput(
                 leadingIcon = leadingIconType(InputType.Email),
                 keyboardActions = KeyboardActions(
                     onNext = {
-                        passwordFocusRequester.requestFocus()
+                        focusRequester.requestFocus()
                     }
                 ),
                 isError = isError,
                 errorMsg = errorMsg,
+                enabled = enabled,
                 onValueChangeListener = onValueChangeListener
             )
         }
@@ -76,9 +79,10 @@ fun ProjectTextInput(
                         keyboardController?.hide()
                     }
                 ),
-                focusRequester = passwordFocusRequester,
+                focusRequester = focusRequester,
                 isError = isError,
                 errorMsg = errorMsg,
+                enabled = enabled,
                 onValueChangeListener = onValueChangeListener
             )
         }
@@ -106,18 +110,19 @@ fun TextInput(
     modifier: Modifier = Modifier,
     leadingIcon: @Composable (() -> Unit)? = null,
     label: String = "",
+    enabled : Boolean = true,
     focusRequester: FocusRequester? = null,
     keyboardActions: KeyboardActions = KeyboardActions.Default,
     isError: State<Boolean> = remember { mutableStateOf(false) },
     errorMsg: State<String> = remember { mutableStateOf("") },
     onValueChangeListener: (value: String) -> Unit = {},
 ) {
-    val textValue = rememberSaveable { mutableStateOf("") }
+    var textValue by rememberSaveable { mutableStateOf("") }
 
     OutlinedTextField(
-        value = textValue.value,
+        value = textValue,
         onValueChange = {
-            textValue.value = it
+            textValue = it
             onValueChangeListener(it)
         },
         modifier = modifier
@@ -139,9 +144,56 @@ fun TextInput(
         keyboardOptions = inputType.keyboardOptions,
         visualTransformation = inputType.visualTransformation,
         keyboardActions = keyboardActions,
-        isError = isError.value
+        isError = isError.value,
+        enabled = enabled
     )
 }
+
+@ExperimentalComposeUiApi
+@Composable
+fun TextInput(
+    text : String,
+    inputType: InputType,
+    modifier: Modifier = Modifier,
+    leadingIcon: @Composable (() -> Unit)? = null,
+    label: String = "",
+    enabled: Boolean = true,
+    focusRequester: FocusRequester? = null,
+    keyboardActions: KeyboardActions = KeyboardActions.Default,
+    isError: State<Boolean> = remember { mutableStateOf(false) },
+    errorMsg: State<String> = remember { mutableStateOf("") },
+    onValueChangeListener: (value: String) -> Unit = {},
+) {
+
+    OutlinedTextField(
+        value = text,
+        onValueChange = {
+            onValueChangeListener(it)
+        },
+        modifier = modifier
+            .then(if(focusRequester!= null) modifier.focusRequester(focusRequester) else modifier)
+            .fillMaxWidth(),
+        leadingIcon = leadingIcon,
+        label = {
+            if (inputType != InputType.FIELD) {
+                Text(text = inputType.label, color = Color.Black)
+            }else {
+                Text(text = label, color = Color.Black)
+            }
+        },
+        colors = TextFieldDefaults.outlinedTextFieldColors(
+            focusedBorderColor = Color.Black,
+            cursorColor = colorResource(id = R.color.Orange)
+        ),
+        shape = RoundedCornerShape(15.dp),
+        keyboardOptions = inputType.keyboardOptions,
+        visualTransformation = inputType.visualTransformation,
+        keyboardActions = keyboardActions,
+        isError = isError.value,
+        enabled = enabled
+    )
+}
+
 
 sealed class InputType(
     val label: String = "",

--- a/app/src/main/java/com/knu/cloud/data/home/image/ImageRemoteDataSource.kt
+++ b/app/src/main/java/com/knu/cloud/data/home/image/ImageRemoteDataSource.kt
@@ -2,6 +2,7 @@ package com.knu.cloud.data.home.image
 
 import com.knu.cloud.model.NetworkResult
 import com.knu.cloud.model.OpenstackResponse
+import com.knu.cloud.model.instanceCreate.ImageData
 import com.knu.cloud.model.instanceCreate.ImagesResponse
 import com.knu.cloud.network.ImageApiService
 import javax.inject.Inject
@@ -11,11 +12,11 @@ class ImageRemoteDataSource @Inject constructor(
     private val imageApiService: ImageApiService
 ) {
 
-    suspend fun getImages() : NetworkResult<OpenstackResponse<ImagesResponse>> {
+    suspend fun getImages() : NetworkResult<List<ImageData>> {
         return imageApiService.getImages()
     }
 
-    suspend fun deleteImage(imageId: String): NetworkResult<OpenstackResponse<String>> {
+    suspend fun deleteImage(imageId: String): NetworkResult<String> {
         return imageApiService.deleteImage(imageId)
     }
 

--- a/app/src/main/java/com/knu/cloud/data/home/instance/InstanceRemoteDataSource.kt
+++ b/app/src/main/java/com/knu/cloud/data/home/instance/InstanceRemoteDataSource.kt
@@ -14,7 +14,7 @@ import javax.inject.Inject
 class InstanceRemoteDataSource @Inject constructor (
     private val instanceApiService : InstanceApiService
 ) {
-    suspend fun getAllInstances(): NetworkResult<OpenstackResponse<InstancesResponse>> {
+    suspend fun getAllInstances(): NetworkResult<List<InstanceData>> {
         Timber.tag("network").d("InstanceRemoteDataSource getAllInstances() 호출")
         return instanceApiService.getAllInstances()
     }
@@ -23,7 +23,7 @@ class InstanceRemoteDataSource @Inject constructor (
         return instanceApiService.getInstance(instanceId)
     }
 
-    suspend fun deleteInstance(instanceId: String): NetworkResult<OpenstackResponse<String>> {
+    suspend fun deleteInstance(instanceId: String): NetworkResult<String> {
         Timber.tag("network").d("InstanceRemoteDataSource deleteInstance($instanceId) 호출")
         return instanceApiService.deleteInstance(instanceId)
     }

--- a/app/src/main/java/com/knu/cloud/data/home/keypair/KeypairRemoteDataSource.kt
+++ b/app/src/main/java/com/knu/cloud/data/home/keypair/KeypairRemoteDataSource.kt
@@ -15,7 +15,7 @@ class KeypairRemoteDataSource @Inject constructor(
     private val keypairApiService: KeypairApiService
 ) {
 
-    suspend fun getKeypairs() : NetworkResult<OpenstackResponse<KeypairsResponse>> {
+    suspend fun getKeypairs() : NetworkResult<List<KeypairData>> {
         return keypairApiService.getKeypairs()
     }
 

--- a/app/src/main/java/com/knu/cloud/data/instanceCreate/InstanceCreateRemoteDataSource.kt
+++ b/app/src/main/java/com/knu/cloud/data/instanceCreate/InstanceCreateRemoteDataSource.kt
@@ -14,19 +14,20 @@ class InstanceCreateRemoteDataSource @Inject constructor(
     suspend fun createInstance(createRequest: CreateRequest) :NetworkResult<AuthResponse<InstanceData>>{
         return instanceCreateApiService.instanceCreate(createRequest)
     }
-    suspend fun getFlavorData() : NetworkResult<OpenstackResponse<FlavorsResponse>> {
+    suspend fun getFlavorData() : NetworkResult<List<FlavorData>> {
+
         return instanceCreateApiService.getFlavorData()
     }
 
-    suspend fun getKeypairData() : NetworkResult<OpenstackResponse<KeypairsResponse>> {
+    suspend fun getKeypairData() : NetworkResult<List<KeypairData>> {
         return instanceCreateApiService.getKeypairData()
     }
 
-    suspend fun getNetworkData() : NetworkResult<OpenstackResponse<NetworksResponse>> {
+    suspend fun getNetworkData() : NetworkResult<List<NetworkData>> {
         return instanceCreateApiService.getNetworkData()
     }
 
-    suspend fun getImages() : NetworkResult<OpenstackResponse<ImagesResponse>> {
+    suspend fun getImages() : NetworkResult<List<ImageData>> {
         return instanceCreateApiService.getImages()
     }
 }

--- a/app/src/main/java/com/knu/cloud/model/home/instance/Instance.kt
+++ b/app/src/main/java/com/knu/cloud/model/home/instance/Instance.kt
@@ -19,6 +19,6 @@ data class InstanceData(
 ): Parcelable
 
 data class InstancesResponse(
-    @SerializedName("servers")
+    @SerializedName("instances")
     val instances : List<InstanceData>
 )

--- a/app/src/main/java/com/knu/cloud/model/instanceCreate/FlavorData.kt
+++ b/app/src/main/java/com/knu/cloud/model/instanceCreate/FlavorData.kt
@@ -2,7 +2,7 @@ package com.knu.cloud.model.instanceCreate
 
 import com.google.gson.annotations.SerializedName
 
-data class FlavorResponse(
+data class FlavorData(
     @SerializedName("id")
     val id: String,
     @SerializedName("name")
@@ -23,5 +23,5 @@ data class FlavorResponse(
 
 data class FlavorsResponse(
     @SerializedName("flavors")
-    val flavors : List<FlavorResponse>
+    val flavors : List<FlavorData>
 )

--- a/app/src/main/java/com/knu/cloud/model/instanceCreate/NetworkData.kt
+++ b/app/src/main/java/com/knu/cloud/model/instanceCreate/NetworkData.kt
@@ -2,7 +2,7 @@ package com.knu.cloud.model.instanceCreate
 
 import com.google.gson.annotations.SerializedName
 
-data class NetworkResponse(
+data class NetworkData(
     @SerializedName("name") // 이름
     val network: String,
     @SerializedName("subnets") // 서브넷
@@ -17,5 +17,5 @@ data class NetworkResponse(
 
 data class NetworksResponse(
     @SerializedName("networks")
-    val networks : List<NetworkResponse>
+    val networks : List<NetworkData>
 )

--- a/app/src/main/java/com/knu/cloud/network/ImageApiService.kt
+++ b/app/src/main/java/com/knu/cloud/network/ImageApiService.kt
@@ -2,6 +2,7 @@ package com.knu.cloud.network
 
 import com.knu.cloud.model.NetworkResult
 import com.knu.cloud.model.OpenstackResponse
+import com.knu.cloud.model.instanceCreate.ImageData
 import com.knu.cloud.model.instanceCreate.ImagesResponse
 import retrofit2.http.DELETE
 import retrofit2.http.GET
@@ -9,9 +10,9 @@ import retrofit2.http.GET
 interface ImageApiService {
 
     @GET("/images")
-    suspend fun getImages(): NetworkResult<OpenstackResponse<ImagesResponse>>
+    suspend fun getImages(): NetworkResult<List<ImageData>>
 
     @DELETE("/images/{id}")
-    suspend fun deleteImage(imageId: String): NetworkResult<OpenstackResponse<String>>
+    suspend fun deleteImage(imageId: String): NetworkResult<String>
 
 }

--- a/app/src/main/java/com/knu/cloud/network/InstanceApiService.kt
+++ b/app/src/main/java/com/knu/cloud/network/InstanceApiService.kt
@@ -12,17 +12,17 @@ import retrofit2.http.*
 
 interface InstanceApiService {
 
-    @GET("/servers")
-    suspend fun getAllInstances() : NetworkResult<OpenstackResponse<InstancesResponse>>
+    @GET("/instances")
+    suspend fun getAllInstances() : NetworkResult<List<InstanceData>>
 
-    @GET("/servers/{id}")
+    @GET("/instances/{id}")
     suspend fun getInstance(
         @Path("id") instanceId : String
     ) : NetworkResult<InstanceData>
 
-    @DELETE("/servers/{id}")
+    @DELETE("/instances/{id}")
     suspend fun deleteInstance(
         @Path("id") instanceId: String
-    ): NetworkResult<OpenstackResponse<String>>
+    ): NetworkResult<String>
 
 }

--- a/app/src/main/java/com/knu/cloud/network/InstanceCreateApiService.kt
+++ b/app/src/main/java/com/knu/cloud/network/InstanceCreateApiService.kt
@@ -12,16 +12,16 @@ import retrofit2.http.POST
 interface InstanceCreateApiService {
 
     @GET("/flavors")
-    suspend fun getFlavorData(): NetworkResult<OpenstackResponse<FlavorsResponse>>
+    suspend fun getFlavorData(): NetworkResult<List<FlavorData>>
 
     @GET("/keypairs")
-    suspend fun getKeypairData(): NetworkResult<OpenstackResponse<KeypairsResponse>>
+    suspend fun getKeypairData(): NetworkResult<List<KeypairData>>
 
     @GET("/networks")
-    suspend fun getNetworkData(): NetworkResult<OpenstackResponse<NetworksResponse>>
+    suspend fun getNetworkData(): NetworkResult<List<NetworkData>>
 
     @GET("/images")
-    suspend fun getImages(): NetworkResult<OpenstackResponse<ImagesResponse>>
+    suspend fun getImages(): NetworkResult<List<ImageData>>
 
     @POST("/api/v1/create")
     suspend fun instanceCreate(

--- a/app/src/main/java/com/knu/cloud/network/KeypairApiService.kt
+++ b/app/src/main/java/com/knu/cloud/network/KeypairApiService.kt
@@ -14,7 +14,7 @@ import retrofit2.http.*
 interface KeypairApiService {
 
     @GET("/keypairs")
-    suspend fun getKeypairs(): NetworkResult<OpenstackResponse<KeypairsResponse>>
+    suspend fun getKeypairs(): NetworkResult<List<KeypairData>>
 
     @GET("/keypairs/{id}")
     suspend fun getKeypair(

--- a/app/src/main/java/com/knu/cloud/network/NetworkUtils.kt
+++ b/app/src/main/java/com/knu/cloud/network/NetworkUtils.kt
@@ -5,7 +5,7 @@ import com.knu.cloud.model.OpenstackResponse
 import com.knu.cloud.model.auth.AuthResponse
 import timber.log.Timber
 
-class RetrofitFailureStateException(error: String ?, val code: Int) : Exception(error)
+class RetrofitFailureStateException(error: String ?, val code: Int = 999) : Exception(error)
 
 fun <T:Any> authResponseToResult(networkResult: NetworkResult<AuthResponse<T>>) :Result<T?>{
     Timber.tag("network").d("AuthResponse ${networkResult.toString()}")
@@ -41,7 +41,11 @@ fun <T:Any> openstackResponseToResult(networkResult: NetworkResult<OpenstackResp
             }
         is NetworkResult.Exception -> {
             Timber.tag("network").d("OpenstackResponse Exception e : ${networkResult.e}")
-            Result.failure(networkResult.e)
+            Result.failure(
+                RetrofitFailureStateException(
+                    networkResult.e.message
+                )
+            )
         }
     }
 }
@@ -57,6 +61,10 @@ fun <T:Any> responseToResult(networkResult: NetworkResult<T>): Result<T?> {
                 networkResult.code
             )
         )
-        is NetworkResult.Exception -> Result.failure(networkResult.e)
+        is NetworkResult.Exception -> Result.failure(
+            RetrofitFailureStateException(
+                networkResult.e.message
+            )
+        )
     }
 }

--- a/app/src/main/java/com/knu/cloud/repository/home/image/ImageRepository.kt
+++ b/app/src/main/java/com/knu/cloud/repository/home/image/ImageRepository.kt
@@ -1,10 +1,11 @@
 package com.knu.cloud.repository.home.image
 
+import com.knu.cloud.model.instanceCreate.ImageData
 import com.knu.cloud.model.instanceCreate.ImagesResponse
 
 interface ImageRepository {
 
-    suspend fun getImages(): Result<ImagesResponse?>
+    suspend fun getImages(): Result<List<ImageData>?>
 
     suspend fun deleteImage(imageId: String) : Result<String?>
 

--- a/app/src/main/java/com/knu/cloud/repository/home/image/ImageRepositoryImpl.kt
+++ b/app/src/main/java/com/knu/cloud/repository/home/image/ImageRepositoryImpl.kt
@@ -2,8 +2,10 @@ package com.knu.cloud.repository.home.image
 
 import com.knu.cloud.data.home.image.ImageRemoteDataSource
 import com.knu.cloud.data.instanceCreate.InstanceCreateRemoteDataSource
+import com.knu.cloud.model.instanceCreate.ImageData
 import com.knu.cloud.model.instanceCreate.ImagesResponse
 import com.knu.cloud.network.openstackResponseToResult
+import com.knu.cloud.network.responseToResult
 import javax.inject.Inject
 import javax.inject.Singleton
 
@@ -14,11 +16,11 @@ class ImageRepositoryImpl @Inject constructor(
     private val remoteDataSource: ImageRemoteDataSource
 ): ImageRepository {
 
-    override suspend fun getImages(): Result<ImagesResponse?> {
-        return openstackResponseToResult(remoteDataSource.getImages())
+    override suspend fun getImages(): Result<List<ImageData>?> {
+        return responseToResult(remoteDataSource.getImages())
     }
 
     override suspend fun deleteImage(imageId: String): Result<String?> {
-        return openstackResponseToResult(remoteDataSource.deleteImage(imageId))
+        return responseToResult(remoteDataSource.deleteImage(imageId))
     }
 }

--- a/app/src/main/java/com/knu/cloud/repository/home/instance/InstanceRepository.kt
+++ b/app/src/main/java/com/knu/cloud/repository/home/instance/InstanceRepository.kt
@@ -6,7 +6,7 @@ import com.knu.cloud.model.instanceCreate.*
 
 interface InstanceRepository {
 
-    suspend fun getAllInstances() : Result<InstancesResponse?>
+    suspend fun getAllInstances() : Result<List<InstanceData>?>
 
     suspend fun getInstance(instanceId : String) : Result<InstanceData?>
 

--- a/app/src/main/java/com/knu/cloud/repository/home/instance/InstanceRepositoryImpl.kt
+++ b/app/src/main/java/com/knu/cloud/repository/home/instance/InstanceRepositoryImpl.kt
@@ -19,12 +19,12 @@ class InstanceRepositoryImpl @Inject constructor(
      * NetworkResult를 받아와서 Result로 Mapping해준다
      * Result로 처리해주는 이유는 viewModel에서 Success/Failure 처리 용이하도록 하기 위함
      */
-    override suspend fun getAllInstances(): Result<InstancesResponse?> =
-        openstackResponseToResult(remoteDataSource.getAllInstances())
+    override suspend fun getAllInstances(): Result<List<InstanceData>?> =
+        responseToResult(remoteDataSource.getAllInstances())
 
     override suspend fun getInstance(instanceId: String): Result<InstanceData?> =
         responseToResult(remoteDataSource.getInstance(instanceId))
 
     override suspend fun deleteInstance(instanceId: String): Result<String?> =
-        openstackResponseToResult(remoteDataSource.deleteInstance(instanceId))
+        responseToResult(remoteDataSource.deleteInstance(instanceId))
 }

--- a/app/src/main/java/com/knu/cloud/repository/home/keypair/KeypairRepository.kt
+++ b/app/src/main/java/com/knu/cloud/repository/home/keypair/KeypairRepository.kt
@@ -7,7 +7,7 @@ import com.knu.cloud.model.keypair.KeypairCreateResponse
 
 interface KeypairRepository {
 
-    suspend fun getKeypairs() : Result<KeypairsResponse?>
+    suspend fun getKeypairs() : Result<List<KeypairData>?>
 
     suspend fun getKeypair(keypairName : String) : Result<KeypairData?>
 

--- a/app/src/main/java/com/knu/cloud/repository/home/keypair/KeypairRepositoryImpl.kt
+++ b/app/src/main/java/com/knu/cloud/repository/home/keypair/KeypairRepositoryImpl.kt
@@ -12,8 +12,8 @@ import javax.inject.Inject
 class KeypairRepositoryImpl @Inject constructor(
     private val remoteDataSource: KeypairRemoteDataSource
 ) : KeypairRepository{
-    override suspend fun getKeypairs(): Result<KeypairsResponse?> {
-        return openstackResponseToResult(remoteDataSource.getKeypairs())
+    override suspend fun getKeypairs(): Result<List<KeypairData>?> {
+        return responseToResult(remoteDataSource.getKeypairs())
     }
 
     override suspend fun getKeypair(keypairName: String): Result<KeypairData?> {

--- a/app/src/main/java/com/knu/cloud/repository/instanceCreate/InstanceCreateRepository.kt
+++ b/app/src/main/java/com/knu/cloud/repository/instanceCreate/InstanceCreateRepository.kt
@@ -4,10 +4,10 @@ import com.knu.cloud.model.home.instance.InstanceData
 import com.knu.cloud.model.instanceCreate.*
 
 interface InstanceCreateRepository {
-    suspend fun getAllFlavorData(): Result<FlavorsResponse?>
-    suspend fun getAllKeypairData(): Result<KeypairsResponse?>
-    suspend fun getAllNetworkData(): Result<NetworksResponse?>
-    suspend fun getAllSourceData(): Result<ImagesResponse?>
+    suspend fun getAllFlavorData(): Result<List<FlavorData>?>
+    suspend fun getAllKeypairData(): Result<List<KeypairData>?>
+    suspend fun getAllNetworkData(): Result<List<NetworkData>?>
+    suspend fun getAllSourceData(): Result<List<ImageData>?>
 
     suspend fun createInstance(createRequest: CreateRequest) : Result<InstanceData?>
 }

--- a/app/src/main/java/com/knu/cloud/repository/instanceCreate/InstanceCreateRepositoryImpl.kt
+++ b/app/src/main/java/com/knu/cloud/repository/instanceCreate/InstanceCreateRepositoryImpl.kt
@@ -4,6 +4,7 @@ import com.knu.cloud.data.instanceCreate.InstanceCreateRemoteDataSource
 import com.knu.cloud.model.home.instance.InstanceData
 import com.knu.cloud.model.instanceCreate.*
 import com.knu.cloud.network.openstackResponseToResult
+import com.knu.cloud.network.responseToResult
 import com.knu.cloud.utils.instanceCreateResponseToResult
 import javax.inject.Inject
 import javax.inject.Singleton
@@ -18,24 +19,24 @@ class InstanceCreateRepositoryImpl @Inject constructor(
         return instanceCreateResponseToResult(instanceCreateResponse)
     }
 
-    override suspend fun getAllFlavorData(): Result<FlavorsResponse?> {
+    override suspend fun getAllFlavorData(): Result<List<FlavorData>?> {
         val flavorResponse = remoteDataSource.getFlavorData()
-        return openstackResponseToResult(flavorResponse)
+        return responseToResult(flavorResponse)
     }
 
-    override suspend fun getAllKeypairData(): Result<KeypairsResponse?> {
+    override suspend fun getAllKeypairData(): Result<List<KeypairData>?> {
         val keypairResponse = remoteDataSource.getKeypairData()
-        return openstackResponseToResult(keypairResponse)
+        return responseToResult(keypairResponse)
     }
 
-    override suspend fun getAllNetworkData(): Result<NetworksResponse?> {
+    override suspend fun getAllNetworkData(): Result<List<NetworkData>?> {
         val networkResponse = remoteDataSource.getNetworkData()
-        return openstackResponseToResult(networkResponse)
+        return responseToResult(networkResponse)
     }
 
-    override suspend fun getAllSourceData(): Result<ImagesResponse?> {
+    override suspend fun getAllSourceData(): Result<List<ImageData>?> {
         val sourceResponse = remoteDataSource.getImages()
-        return openstackResponseToResult(sourceResponse)
+        return responseToResult(sourceResponse)
     }
 
 }

--- a/app/src/main/java/com/knu/cloud/screens/auth/login/LoginScreen.kt
+++ b/app/src/main/java/com/knu/cloud/screens/auth/login/LoginScreen.kt
@@ -213,7 +213,7 @@ fun UserForm(
         ProjectTextInput(
             type = TextInputType.Email,
             keyboardController = keyboardController,
-            passwordFocusRequester = passwordFocusRequester
+            focusRequester = passwordFocusRequester
         ) { email ->
             viewModel.updateUserEmail(email)
         }
@@ -221,7 +221,7 @@ fun UserForm(
         ProjectTextInput(
             type = TextInputType.PASSWORD,
             keyboardController = keyboardController,
-            passwordFocusRequester = passwordFocusRequester
+            focusRequester = passwordFocusRequester
         ) { password ->
             viewModel.updateUserPassword(password)
         }

--- a/app/src/main/java/com/knu/cloud/screens/home/image/ImageViewModel.kt
+++ b/app/src/main/java/com/knu/cloud/screens/home/image/ImageViewModel.kt
@@ -45,7 +45,7 @@ class ImageViewModel @Inject constructor (
                 .onSuccess { images ->
                     if (images != null) {
                         Timber.d("images :  $images")
-                        _uiState.update { it.copy(images = convertImageData(images.images), isLoading = false) }
+                        _uiState.update { it.copy(images = convertImageData(images), isLoading = false) }
                     }else{
                         _uiState.update { it.copy(images = emptyList(), isLoading = false) }
                     }

--- a/app/src/main/java/com/knu/cloud/screens/home/instance/InstanceViewModel.kt
+++ b/app/src/main/java/com/knu/cloud/screens/home/instance/InstanceViewModel.kt
@@ -44,7 +44,7 @@ class InstanceViewModel @Inject constructor (
             instanceRepository.getAllInstances()
                 .onSuccess { instanceList ->
                     if (instanceList != null) {
-                        _uiState.update { it.copy(instances = instanceList.instances, isLoading = false) }
+                        _uiState.update { it.copy(instances = instanceList, isLoading = false) }
                     }else{
                         _uiState.update { it.copy(instances = emptyList(), isLoading = false) }
                     }

--- a/app/src/main/java/com/knu/cloud/screens/home/keypairs/KeypairsViewModel.kt
+++ b/app/src/main/java/com/knu/cloud/screens/home/keypairs/KeypairsViewModel.kt
@@ -44,7 +44,7 @@ class KeypairsViewModel @Inject constructor (
                 .onSuccess { keypairs ->
                     if (keypairs != null) {
                         Timber.d("keypairs : $keypairs")
-                        _uiState.update { it.copy(keypairs = keypairs.keypairs, isLoading = false) }
+                        _uiState.update { it.copy(keypairs = keypairs, isLoading = false) }
                     } else {
                         _uiState.update { it.copy(keypairs = emptyList(), isLoading = false) }
                     }

--- a/app/src/main/java/com/knu/cloud/screens/instanceCreate/InstanceCreateScreen.kt
+++ b/app/src/main/java/com/knu/cloud/screens/instanceCreate/InstanceCreateScreen.kt
@@ -3,12 +3,10 @@ package com.knu.cloud.screens.instanceCreate
 import androidx.compose.foundation.layout.*
 import androidx.compose.material.*
 import androidx.compose.runtime.*
-import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.hilt.navigation.compose.hiltViewModel
-import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.currentBackStackEntryAsState
@@ -49,7 +47,7 @@ fun InstanceCreateScreen(
     Timber.tag("dialog").d("isDialogOpen : ${isDialogOpen}")
     if(isDialogOpen){
         CreateLoadingDialog()
-        instanceCreateViewModel.startCoroutine(context)
+        instanceCreateViewModel.createInstance(context)
     }
 
     Row(modifier = Modifier.fillMaxSize()) {

--- a/app/src/main/java/com/knu/cloud/screens/instanceCreate/InstanceCreateUiStates.kt
+++ b/app/src/main/java/com/knu/cloud/screens/instanceCreate/InstanceCreateUiStates.kt
@@ -1,0 +1,42 @@
+package com.knu.cloud.screens.instanceCreate
+
+import com.knu.cloud.model.instanceCreate.FlavorData
+import com.knu.cloud.model.instanceCreate.ImageData
+import com.knu.cloud.model.instanceCreate.KeypairData
+import com.knu.cloud.model.instanceCreate.NetworkData
+
+data class InstanceCreateDetailUiState(
+    val projectName :String = "demo",
+    val instanceName : String = "",
+    val description : String = "",
+    val availabilityZone : String = "Nova",
+    val addCount : Int = 1,                                     // 개수, 값이 바뀔때마다 Total Instances차트의 Added도 업데이트 된다
+    val currentCount : Int = 0,
+    val totalCount : Int = 10                                             // remaining을 구하기 위함
+)
+
+data class InstanceCreateSourceUiState(
+    val selectedTitle : String = "Image",
+    val volumeSize : Int = 1,
+    val uploadSource : ImageData? = null,
+    val uploadSourceIndex : Int = 0,
+    val possibleSources : List<ImageData> = emptyList()
+)
+
+data class InstanceCreateFlavorUiState(
+    val uploadFlavor : FlavorData? = null,
+    val uploadFlavorIndex : Int = 0,
+    val possibleFlavors : List<FlavorData> = emptyList()
+)
+
+data class InstanceCreateNetworkUiState(
+    val uploadNetwork : NetworkData? = null,
+    val uploadNetworkIndex : Int = 0,
+    val possibleNetworks : List<NetworkData> = emptyList()
+)
+
+data class InstanceCreateKeypairUiState(
+    val uploadKeypair : KeypairData? = null,
+    val uploadKeypairIndex : Int = 0,
+    val possibleKeypairs : List<KeypairData> = emptyList()
+)

--- a/app/src/main/java/com/knu/cloud/screens/instanceCreate/detail/DetailScreen.kt
+++ b/app/src/main/java/com/knu/cloud/screens/instanceCreate/detail/DetailScreen.kt
@@ -4,6 +4,7 @@ import android.widget.Toast
 import androidx.compose.foundation.*
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.text.KeyboardActions
 import androidx.compose.material.*
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.KeyboardArrowDown
@@ -13,6 +14,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.ExperimentalComposeUiApi
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
+import androidx.compose.ui.focus.FocusRequester
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.platform.LocalSoftwareKeyboardController
@@ -24,15 +26,15 @@ import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.layout.onGloballyPositioned
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalDensity
+import androidx.compose.ui.platform.LocalFocusManager
+import androidx.compose.ui.tooling.preview.Devices
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.toSize
 import androidx.hilt.navigation.compose.hiltViewModel
 import com.knu.cloud.R
 import com.knu.cloud.components.DonutChart
 import com.knu.cloud.components.DonutChartComponent
-import com.knu.cloud.components.text_input.ProjectTextInput
-import com.knu.cloud.components.text_input.TextInputType
-import com.knu.cloud.components.text_input.addFocusCleaner
+import com.knu.cloud.components.text_input.*
 import com.knu.cloud.screens.instanceCreate.InstanceCreateViewModel
 import timber.log.Timber
 
@@ -66,10 +68,11 @@ fun DetailScreen(
 fun Detail(
     viewModel: InstanceCreateViewModel = hiltViewModel(),
 ) {
-    val coroutineScope = rememberCoroutineScope()
     val context = LocalContext.current
     val keyboardController = LocalSoftwareKeyboardController.current
+    val focusManager = LocalFocusManager.current
     val detailsUiState by viewModel.detailUiState.collectAsState()
+
 
     Row(
         modifier = Modifier
@@ -91,9 +94,16 @@ fun Detail(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(top = 15.dp, start = 8.dp, end = 15.dp, bottom = 5.dp)
             )
-            ProjectTextInput(
-                type = TextInputType.FIELD,
-                keyboardController = keyboardController,
+            TextInput(
+                text = detailsUiState.projectName,
+                inputType = InputType.FIELD,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        keyboardController.hide()
+                        focusManager.clearFocus()
+                    }
+                ),
+                enabled = false,
                 onValueChangeListener = {
                     viewModel.updateDetailsUiState(detailsUiState.copy(projectName = it))
                 }
@@ -104,9 +114,15 @@ fun Detail(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(top = 25.dp, start = 8.dp, end = 15.dp, bottom = 5.dp)
             )
-            ProjectTextInput(
-                type = TextInputType.FIELD,
-                keyboardController = keyboardController,
+            TextInput(
+                text = detailsUiState.instanceName,
+                inputType = InputType.FIELD,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        keyboardController.hide()
+                        focusManager.clearFocus()
+                    }
+                ),
                 onValueChangeListener = {
                     viewModel.updateDetailsUiState(detailsUiState.copy(instanceName = it))
                 }
@@ -117,14 +133,19 @@ fun Detail(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(top = 25.dp, start = 8.dp, end = 15.dp, bottom = 5.dp)
             )
-            ProjectTextInput(
-                type = TextInputType.FIELD,
-                keyboardController = keyboardController,
+            TextInput(
+                text = detailsUiState.description,
+                inputType = InputType.FIELD,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        keyboardController.hide()
+                        focusManager.clearFocus()
+                    }
+                ),
                 onValueChangeListener = {
                     viewModel.updateDetailsUiState(detailsUiState.copy(description = it))
                 }
             )
-
             Text(
                 text = stringResource(id = R.string.IC_Detail_Header_Area),
                 fontWeight = FontWeight.Bold,
@@ -132,6 +153,8 @@ fun Detail(
                 modifier = Modifier.padding(top = 25.dp, start = 8.dp, end = 15.dp, bottom = 10.dp)
             )
             DropdownCompute(   // 가용구역 선택
+                items = listOf("Nova"),
+                selectedItem = detailsUiState.availabilityZone,
                 onItemClicked = {
                     viewModel.updateDetailsUiState(detailsUiState.copy(availabilityZone = it))
                 }
@@ -143,16 +166,22 @@ fun Detail(
                 textAlign = TextAlign.Center,
                 modifier = Modifier.padding(top = 25.dp, start = 8.dp, end = 15.dp, bottom = 5.dp)
             )
-            ProjectTextInput(
-                type = TextInputType.FIELD,
-                keyboardController = keyboardController,
-                onValueChangeListener = {
-                    try {
-                        viewModel.updateDetailsUiState(detailsUiState.copy(addCount = it.toInt()))
-                    }catch (e : NumberFormatException){
-                        Toast.makeText(context,"정수를 입력하세요",Toast.LENGTH_SHORT)
+            var addCountString by remember { mutableStateOf(detailsUiState.addCount.toString()) }
+            TextInput(
+                text = addCountString,
+                inputType = InputType.FIELD,
+                keyboardActions = KeyboardActions(
+                    onDone = {
+                        keyboardController.hide()
+                        try {
+                            viewModel.updateDetailsUiState(detailsUiState.copy(addCount = addCountString.toInt()))
+                        }catch (e : NumberFormatException){
+                            Toast.makeText(context,"정수를 입력하세요",Toast.LENGTH_SHORT).show()
+                        }
+                        focusManager.clearFocus()
                     }
-                }
+                ),
+                onValueChangeListener = { addCountString = it}
             )
         } // Column End
 
@@ -164,9 +193,7 @@ fun Detail(
             verticalArrangement = Arrangement.Center,
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
-            DonutChartComponent(
-                // 인스턴스 현황
-                // Current Usage, Added, Remaining 순
+            DonutChartComponent(                                         // 인스턴스 현황 Current Usage, Added, Remaining 순
                 chartValues = listOf(
                     detailsUiState.currentCount,
                     detailsUiState.addCount,
@@ -179,11 +206,11 @@ fun Detail(
 
 @Composable
 fun DropdownCompute(
+    items : List<String> = listOf("Nova"),
+    selectedItem : String = remember { mutableStateOf(items[0])}.value,
     onItemClicked : (String) -> Unit
 ) {
     var expanded by remember { mutableStateOf(false) }
-    val items = listOf("Nova") // Nova 하나로 고정
-    var selectedIndex by remember { mutableStateOf(0) }
     var fieldSize by remember { mutableStateOf(Size.Zero)}
 
     Box (
@@ -207,7 +234,7 @@ fun DropdownCompute(
             horizontalArrangement = Arrangement.SpaceBetween
         ) {
             Text (
-                text = items[selectedIndex],
+                text = selectedItem,
             )
             Icon(
                 imageVector = if (expanded) Icons.Default.KeyboardArrowUp else Icons.Default.KeyboardArrowDown,
@@ -222,10 +249,9 @@ fun DropdownCompute(
                 .width(with(LocalDensity.current) { fieldSize.width.toDp() })
                 .height(60.dp),
         ) {
-            items.forEachIndexed { index, item ->
+            items.forEach {item ->
                 DropdownMenuItem(
                     onClick = {
-                        selectedIndex = index
                         expanded = false
                         onItemClicked(item)
                 }) {
@@ -239,7 +265,7 @@ fun DropdownCompute(
 }
 
 
-@Preview(showBackground = true)
+@Preview(showBackground = true, device = Devices.TABLET)
 @Composable
 fun CustomDonutChart() {
 

--- a/app/src/main/java/com/knu/cloud/screens/instanceCreate/flavor/FlavorScreen.kt
+++ b/app/src/main/java/com/knu/cloud/screens/instanceCreate/flavor/FlavorScreen.kt
@@ -18,7 +18,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.knu.cloud.R
 import com.knu.cloud.components.data_grid.*
 import com.knu.cloud.components.text_input.addFocusCleaner
-import com.knu.cloud.model.instanceCreate.FlavorResponse
+import com.knu.cloud.model.instanceCreate.FlavorData
 
 @ExperimentalComposeUiApi
 @Composable
@@ -48,11 +48,10 @@ fun Flavor(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    var uploadExpanded by remember { mutableStateOf(false) }
+    var uploadExpanded by remember { mutableStateOf(true) }
     var possibleExpanded by remember { mutableStateOf(true) }
 
-    val uploadList = viewModel.uploadFlavor.value
-    val possibleList = viewModel.possibleFlavor.value
+    val uiState by viewModel.flavorUiState.collectAsState()
 
     LazyColumn(
         modifier = Modifier
@@ -72,22 +71,24 @@ fun Flavor(
         item {
             DataGridBar(
                 type = "할당됨",
-                numbers = viewModel.uploadFlavor.value.size,
+                numbers = if (uiState.uploadFlavor== null) 0 else 1,
                 expanded = uploadExpanded
             ) {
                 uploadExpanded = it
             }
         }
         if (uploadExpanded) {
-            itemsIndexed(uploadList) { index, item ->
-                if (index == 0) DataGridHeader(screenType = "Flavor")
-                DataGridElementList<FlavorResponse>(
-                    item = item,
-                    index = index,
-                    type = "할당됨",
-                    screenType = "Flavor"
-                ) { it, idx ->
-                    viewModel.deleteFlavor(it, idx)
+            if(uiState.uploadFlavor != null){
+                itemsIndexed(listOf(uiState.uploadFlavor!!)) { index, item ->
+                    if (index == 0) DataGridHeader(screenType = "Flavor")
+                    DataGridElementList<FlavorData>(
+                        item = item,
+                        index = index,
+                        type = "할당됨",
+                        screenType = "Flavor"
+                    ) { it, idx ->
+                        viewModel.deleteFlavor(it)
+                    }
                 }
             }
         }
@@ -96,22 +97,23 @@ fun Flavor(
         item {
             DataGridBar(
                 type = "사용 가능",
-                numbers = viewModel.possibleFlavor.value.size,
+                numbers = uiState.possibleFlavors.size,
                 expanded = possibleExpanded,
             ) {
                 possibleExpanded = it
             }
         }
         if (possibleExpanded) {
-            itemsIndexed(possibleList) { index, item ->
+            itemsIndexed(uiState.possibleFlavors) { index, item ->
                 if (index == 0) DataGridHeader(screenType = "Flavor")
-                DataGridElementList<FlavorResponse>(
+                DataGridElementList<FlavorData>(
                     item = item,
                     index = index,
                     type = "사용 가능",
                     screenType = "Flavor"
                 ) { it, idx ->
-                    viewModel.uploadFlavor(it, idx)
+                    if(uiState.uploadFlavor != null) viewModel.updateFlavor(it,idx)
+                    else viewModel.uploadFlavor(it,idx)
                 }
             }
         }

--- a/app/src/main/java/com/knu/cloud/screens/instanceCreate/keypair/KeypairScreen.kt
+++ b/app/src/main/java/com/knu/cloud/screens/instanceCreate/keypair/KeypairScreen.kt
@@ -63,11 +63,10 @@ fun Keypair(
 ) {
     val showCreateKeypairDialog by viewModel.showCreateKeypiarDialog   // AlertDialog 띄우기 위한 State 정의
 
-    var uploadExpanded by remember { mutableStateOf(false) }
+    var uploadExpanded by remember { mutableStateOf(true) }
     var possibleExpanded by remember { mutableStateOf(true) }
 
-    val uploadList by viewModel.uploadKeypair.collectAsState()
-    val possibleList by viewModel.possibleKeypair.collectAsState()
+    val uiState by viewModel.keypairUiState.collectAsState()
 
     LazyColumn(
         modifier = Modifier
@@ -101,23 +100,26 @@ fun Keypair(
         item {
             DataGridBar(
                 type = "할당됨",
-                numbers = uploadList.size,
+                numbers = if (uiState.uploadKeypair== null) 0 else 1,
                 expanded = uploadExpanded
             ) {
                 uploadExpanded = it
             }
         }
         if (uploadExpanded) {
-            itemsIndexed(uploadList) { index, item ->
-                if (index == 0) DataGridHeader(screenType = "Keypair")
-                DataGridElementList<KeypairData>(
-                    item = item,
-                    index = index,
-                    type = "할당됨",
-                    screenType = "Keypair"
-                ) { it, idx ->
-                    viewModel.deleteKeypair(it, idx)
+            if(uiState.uploadKeypair != null){
+                itemsIndexed(listOf(uiState.uploadKeypair!!)) { index, item ->
+                    if (index == 0) DataGridHeader(screenType = "Keypair")
+                    DataGridElementList<KeypairData>(
+                        item = item,
+                        index = index,
+                        type = "할당됨",
+                        screenType = "Keypair"
+                    ) { it, idx ->
+                        viewModel.deleteKeypair(it)
+                    }
                 }
+
             }
         }
 
@@ -125,14 +127,14 @@ fun Keypair(
         item {
             DataGridBar(
                 type = "사용 가능",
-                numbers = possibleList.size,
+                numbers = uiState.possibleKeypairs.size,
                 expanded = possibleExpanded,
             ) {
                 possibleExpanded = it
             }
         }
         if (possibleExpanded) {
-            itemsIndexed(possibleList) { index, item ->
+            itemsIndexed(uiState.possibleKeypairs) { index, item ->
                 if (index == 0) DataGridHeader(screenType = "Keypair")
                 DataGridElementList<KeypairData>(
                     item = item,
@@ -140,7 +142,8 @@ fun Keypair(
                     type = "사용 가능",
                     screenType = "Keypair"
                 ) { it, idx ->
-                    viewModel.uploadKeypair(it, idx)
+                    if(uiState.uploadKeypair != null) viewModel.updateKeypair(it,idx)
+                    else viewModel.uploadKeypair(it,idx)
                 }
             }
         }

--- a/app/src/main/java/com/knu/cloud/screens/instanceCreate/network/NetworkScreen.kt
+++ b/app/src/main/java/com/knu/cloud/screens/instanceCreate/network/NetworkScreen.kt
@@ -17,7 +17,7 @@ import androidx.hilt.navigation.compose.hiltViewModel
 import com.knu.cloud.R
 import com.knu.cloud.components.data_grid.*
 import com.knu.cloud.components.text_input.addFocusCleaner
-import com.knu.cloud.model.instanceCreate.NetworkResponse
+import com.knu.cloud.model.instanceCreate.NetworkData
 
 @ExperimentalComposeUiApi
 @Composable
@@ -46,11 +46,10 @@ fun Network(
 ) {
     val keyboardController = LocalSoftwareKeyboardController.current
 
-    var uploadExpanded by remember { mutableStateOf(false) }
+    var uploadExpanded by remember { mutableStateOf(true) }
     var possibleExpanded by remember { mutableStateOf(true) }
 
-    val uploadList = viewModel.uploadNetwork.value
-    val possibleList = viewModel.possibleNetwork.value
+    val uiState by viewModel.networkUiState.collectAsState()
 
     LazyColumn(
         modifier = Modifier
@@ -70,22 +69,24 @@ fun Network(
         item {
             DataGridBar(
                 type = "할당됨",
-                numbers = viewModel.uploadNetwork.value.size,
+                numbers = if (uiState.uploadNetwork== null) 0 else 1,
                 expanded = uploadExpanded
             ) {
                 uploadExpanded = it
             }
         }
         if (uploadExpanded) {
-            itemsIndexed(uploadList) { index, item ->
-                if (index == 0) DataGridHeader(screenType = "Network")
-                DataGridElementList<NetworkResponse>(
-                    item = item,
-                    index = index,
-                    type = "할당됨",
-                    screenType = "Network"
-                ) { it, idx ->
-                    viewModel.deleteNetwork(it, idx)
+            if(uiState.uploadNetwork != null){
+                itemsIndexed(listOf(uiState.uploadNetwork!!)) { index, item ->
+                    if (index == 0) DataGridHeader(screenType = "Network")
+                    DataGridElementList<NetworkData>(
+                        item = item,
+                        index = index,
+                        type = "할당됨",
+                        screenType = "Network"
+                    ) { it, idx ->
+                        viewModel.deleteNetwork(it)
+                    }
                 }
             }
         }
@@ -94,22 +95,23 @@ fun Network(
         item {
             DataGridBar(
                 type = "사용 가능",
-                numbers = viewModel.possibleNetwork.value.size,
+                numbers = uiState.possibleNetworks.size,
                 expanded = possibleExpanded,
             ) {
                 possibleExpanded = it
             }
         }
         if (possibleExpanded) {
-            itemsIndexed(possibleList) { index, item ->
+            itemsIndexed(uiState.possibleNetworks) { index, item ->
                 if (index == 0) DataGridHeader(screenType = "Network")
-                DataGridElementList<NetworkResponse>(
+                DataGridElementList<NetworkData>(
                     item = item,
                     index = index,
                     type = "사용 가능",
                     screenType = "Network"
                 ) { it, idx ->
-                    viewModel.uploadNetwork(it, idx)
+                    if(uiState.uploadNetwork != null) viewModel.updateNetwork(it,idx)
+                    else viewModel.uploadNetwork(it,idx)
                 }
             }
         }

--- a/app/src/main/java/com/knu/cloud/utils/DataGridUtils.kt
+++ b/app/src/main/java/com/knu/cloud/utils/DataGridUtils.kt
@@ -15,9 +15,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.dp
 import com.knu.cloud.R
-import com.knu.cloud.model.instanceCreate.FlavorResponse
+import com.knu.cloud.model.instanceCreate.FlavorData
 import com.knu.cloud.model.instanceCreate.KeypairData
-import com.knu.cloud.model.instanceCreate.NetworkResponse
+import com.knu.cloud.model.instanceCreate.NetworkData
 import com.knu.cloud.model.instanceCreate.ImageData
 
 object FlavorUtils{
@@ -91,7 +91,7 @@ fun FlavorHeaderTableCell() {
 }
 
 @Composable
-fun FlavorDataTableCell(item: FlavorResponse, index: Int, type: String, onClickButton: (FlavorResponse, Int) -> Unit) {
+fun FlavorDataTableCell(item: FlavorData, index: Int, type: String, onClickButton: (FlavorData, Int) -> Unit) {
     var backGcolor = Color.White
     if (index % 2 == 0) {
         backGcolor = Color.LightGray
@@ -207,7 +207,7 @@ fun NetworkHeaderTableCell() {
 }
 
 @Composable
-fun NetworkDataTableCell(item: NetworkResponse, index: Int, type: String, onClickButton: (NetworkResponse, Int) -> Unit) {
+fun NetworkDataTableCell(item: NetworkData, index: Int, type: String, onClickButton: (NetworkData, Int) -> Unit) {
     var backGcolor = Color.White
     if (index % 2 == 0) {
         backGcolor = Color.LightGray


### PR DESCRIPTION
## Summary
- InstanceCreate에 들어가는 각 페이지 따로 UiState 만들어서 관리하도록 변경
- InstanceCreate 각 페이지에서 할당된 것들 원래는 리스트로 관리했었는데 1개만 가능하도록 변경
- 준이가 FastAPI Response 형식 바꿔서 일단 전반적으로 수정함
- NetworkResult Exception일 때 RetrofitFailureStateException로 wrapping 안해서 앱 꺼지는 오류 해결
   - 오류 로그 형태로 남음

## ToDo
- DashBoard 부분 response 형식 변경에 따른 수정 필요